### PR TITLE
Fixes #2. Point readme link to polymer-project core docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 core-elements
 =========
 
-See //polymer.github.io/core-elements
+See the [Core Elements docs](http://www.polymer-project.org/components/core-docs/index.html)


### PR DESCRIPTION
There's no polymer.github.io page for core-elements so I thought this could point at the Polymer site instead.
