### PR TITLE
Remove core-bind from core-elements

### DIFF
--- a/core-elements.html
+++ b/core-elements.html
@@ -19,7 +19,6 @@ See `bower.json` for the complete list of components.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../core-ajax/core-ajax.html">
 <link rel="import" href="../core-animated-pages/core-animated-pages.html">
-<link rel="import" href="../core-bind/core-bind.html">
 <link rel="import" href="../core-collapse/core-collapse.html">
 <link rel="import" href="../core-doc-viewer/core-doc-viewer.html">
 <link rel="import" href="../core-drag-drop/core-drag-drop.html">


### PR DESCRIPTION
the core-bind package seems to be deprecated. Moreover, it isn't listed in the bower.json file
