### PR TITLE
Change core-dropdown to core-dropdown-menu

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "core-docs": "Polymer/core-docs#master",
     "core-drag-drop": "Polymer/core-drag-drop#master",
     "core-drawer-panel": "Polymer/core-drawer-panel#master",
-    "core-dropdown": "Polymer/core-dropdown#master",
+    "core-dropdown-menu": "Polymer/core-dropdown-menu#master",
     "core-field": "Polymer/core-field#master",
     "core-header-panel": "Polymer/core-header-panel#master",
     "core-icon-button": "Polymer/core-icon-button#master",


### PR DESCRIPTION
core-dropdown was renamed to core-dropdown-menu, this PR changes the reference in bower.json (see https://github.com/Polymer/core-dropdown/issues/1)
